### PR TITLE
Fix amp handling, update trackers

### DIFF
--- a/go-traceurl.go
+++ b/go-traceurl.go
@@ -140,8 +140,9 @@ func traceHandler(w http.ResponseWriter, r *http.Request, config *Config) {
 
 		// Sanitize URL input using bluemonday
 		sanitizedURL := bluemonday.UGCPolicy().Sanitize(rawURL)
+		fixedSanitizedURL := strings.ReplaceAll(sanitizedURL, "&amp;", "&")
 
-		redirectURL, hops, err := followRedirects(sanitizedURL)
+		redirectURL, hops, err := followRedirects(fixedSanitizedURL)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("Error following redirects: %s", err), http.StatusInternalServerError)
 			return

--- a/static/js/cleanUrls.js
+++ b/static/js/cleanUrls.js
@@ -55,8 +55,10 @@ window.addEventListener("DOMContentLoaded", () => {
                 "cid",
                 "ck_subscriber_id",
                 "cmpid",
+                "ea.tracking.id",
                 "fbclid",
                 "gclid",
+                "mailId",
                 "msclkid",
                 "mc_cid",
                 "mc_eid",
@@ -64,6 +66,7 @@ window.addEventListener("DOMContentLoaded", () => {
 
             const isBadPart =
                 badParts.includes(param) ||
+                param.startsWith("cm_") ||
                 param.startsWith("pk_") ||
                 param.startsWith("utm_");
             if (isBadPart) {


### PR DESCRIPTION
- Fix glitch where ampersands being converted to entities was causing issues with Go's net/url. (See: golang.org/issue/25192)
- Remove a few additional common trackers.