### PR TITLE
Partial fix for outlook infinite redirect problem

### DIFF
--- a/web-handlers.go
+++ b/web-handlers.go
@@ -210,10 +210,6 @@ func handleRelativeRedirect(previousURL *url.URL, location string, requestURL *u
 		return nil, err
 	}
 
-	if strings.HasPrefix(location, "https://outlook.office365.com") {
-		return redirectURL, nil
-	}
-
 	if redirectURL.Scheme == "" {
 		// If the scheme is missing, set it to the scheme of the previous URL or the request URL
 		if previousURL != nil {

--- a/web-handlers.go
+++ b/web-handlers.go
@@ -141,6 +141,18 @@ func followRedirects(urlStr string, w http.ResponseWriter, r *http.Request) (str
 				}
 				return "", []Hop{}, nil // Return empty slice of Hop when redirect location is not found
 			}
+			if strings.HasPrefix(location, "https://outlook.office365.com") {
+				// Only include the final request as the last hop
+				finalHop := Hop{
+					Number:     number + 2, // Increment the hop number for the final request
+					URL:        location,
+					StatusCode: http.StatusOK, // Set the status code to 200 for the final request
+				}
+				finalHop.StatusCodeClass = getStatusCodeClass(http.StatusOK)
+				hops = append(hops, finalHop)
+
+				return location, hops, nil
+			}
 
 			redirectURL, err := handleRelativeRedirect(previousURL, location, req.URL)
 			if err != nil {
@@ -196,6 +208,10 @@ func handleRelativeRedirect(previousURL *url.URL, location string, requestURL *u
 	redirectURL, err := url.Parse(location)
 	if err != nil {
 		return nil, err
+	}
+
+	if strings.HasPrefix(location, "https://outlook.office365.com") {
+		return redirectURL, nil
 	}
 
 	if redirectURL.Scheme == "" {


### PR DESCRIPTION
- Try to improve handling of outlook links that can cause an infinite redirect loop.

